### PR TITLE
Always wrap errors

### DIFF
--- a/lib/BeanBag.js
+++ b/lib/BeanBag.js
@@ -7,6 +7,7 @@ var EventEmitter = require('events').EventEmitter,
     lines = require('lines'),
     crypto = require('crypto'),
     httpErrors = require('httperrors'),
+    socketErrors = require('socketerrors'),
     os = require('os'),
     passError = require('passerror'),
     http = require('http'),
@@ -232,8 +233,23 @@ _.extend(BeanBag.prototype, {
         };
 
         function handleError(err, response) {
+            var socketError;
+
             if (!done) {
                 done = true;
+
+                // if what came up was a plain error convert it to an httpError
+                if (!err.statusCode) {
+                    socketError = socketErrors(err);
+
+                    if (!socketError.NotSocketError) {
+                        err = socketError;
+                    } else {
+                        // convert to a 500 internal server error
+                        err = new httpErrors[500](err.message);
+                    }
+                }
+
                 that.emit('failedRequest', { url: url, requestOptions: requestOptions, response: response, err: err, numRetriesLeft: numRetriesLeft });
                 if (cb) {
                     cb(err);

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "httperrors": "0.3.0",
     "lines": "1.0.1",
     "passerror": "0.0.1",
+    "socketerrors": "0.0.1",
     "underscore": "1.4.0"
   },
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "jshint": "2.7.0",
     "messy": "6.1.0",
     "mocha": "2.2.4",
-    "unexpected": "7.0.1",
+    "unexpected": "7.4.3",
     "unexpected-messy": "3.0.3",
-    "unexpected-mitm": "5.0.3"
+    "unexpected-mitm": "5.4.0"
   }
 }


### PR DESCRIPTION
This pull request addresses #1 - it ensures all errors that escape the library are httpErrors. This allows a really nice pattern where callers acting as HTTP handlers need only do:

function callback(err) {
    res.status(err.statusCode).send();
}

to pass the error code up. I discovered this when I got a TypeError because I'd passed undefined statusCode to status().

I'd appreciate an extra eyeball on the selected of the 'nested' errorMode in the assertion I added to the test suite.

Thanks, Alex J Burke.
