### PR TITLE
Exhaust error reponse bodies to avoid connection pool stall.

### DIFF
--- a/lib/BeanBag.js
+++ b/lib/BeanBag.js
@@ -306,13 +306,26 @@ _.extend(BeanBag.prototype, {
                     handleError(err);
                 }
             }).on('response', function (response) {
+                var responseError;
+
                 if (done) {
                     return;
                 }
+
+                function returnSuccessOrError(err) {
+                    err = err || responseError;
+
+                    if (!err) {
+                        handleSuccess(response);
+                    } else {
+                        handleError(err, response);
+                    }
+                }
+
                 numRetriesLeft = 0;
                 response.cacheInfo = { headers: {} };
                 if (response.statusCode >= 400) {
-                    return handleError(new httpErrors[response.statusCode](), response);
+                    responseError = new httpErrors[response.statusCode]();
                 } else if (response.statusCode === 304) {
                     response.cacheInfo.notModified = true;
                     body = null;
@@ -322,7 +335,11 @@ _.extend(BeanBag.prototype, {
                         response.cacheInfo.headers[headerName] = response.headers[headerName];
                     }
                 });
-                eventEmitter.emit('response', response);
+
+                if (!responseError) {
+                  eventEmitter.emit('response', response);
+                }
+
                 if (options.streamRows) {
                     response.setEncoding('utf-8');
                     lines(response);
@@ -355,16 +372,12 @@ _.extend(BeanBag.prototype, {
                                 eventEmitter.emit('row', row);
                             }
                         }
-                    }).on('error', function (err) {
-                        handleError(err, response);
-                    }).on('end', function () {
-                        handleSuccess(response);
-                    });
+                    }).on('error', returnSuccessOrError).on('end', returnSuccessOrError);
                 } else if (cb) {
                     var responseBodyChunks = [];
                     response.on('data', function (responseBodyChunk) {
                         responseBodyChunks.push(responseBodyChunk);
-                    }).on('end', function () {
+                    }).on('error', returnSuccessOrError).on('end', function () {
                         currentRequest = null;
                         if (responseBodyChunks.length > 0) {
                             response.body = Buffer.concat(responseBodyChunks);
@@ -376,9 +389,7 @@ _.extend(BeanBag.prototype, {
                                 }
                             }
                         }
-                        handleSuccess(response);
-                    }).on('error', function (err) {
-                        handleError(err, response);
+                        returnSuccessOrError();
                     });
                 }
             });


### PR DESCRIPTION
Hey,

Landing this on mine mainly for the purposes of review - I'll land it directly once we've had a chance to discuss it.

I think the fix works by correctly exhausting the body. The test sets the maxSockets really low such that it will only succeed if the sockets were correctly closed and I got the code down to only an additional include of http, although it does start a server up.

AJB
